### PR TITLE
Add study quiz web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Study Quiz App</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Study Quiz App</h1>
+        <div id="start-screen">
+            <p>Select a topic to begin:</p>
+            <button class="topic-btn" data-topic="math">Math</button>
+            <button class="topic-btn" data-topic="history">History</button>
+            <button class="topic-btn" data-topic="science">Science</button>
+        </div>
+
+        <div id="quiz-screen" class="hidden">
+            <div id="progress"></div>
+            <div id="question"></div>
+            <div id="options"></div>
+            <button id="next-btn" class="hidden">Next</button>
+        </div>
+
+        <div id="score-screen" class="hidden">
+            <h2>Quiz Complete!</h2>
+            <p id="final-score"></p>
+            <p id="high-score" class="hidden"></p>
+            <button id="restart-btn">Restart</button>
+        </div>
+        <div class="controls">
+            <label><input type="checkbox" id="sound-toggle" checked> Sound</label>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,177 @@
+const questions = {
+    math: [
+        {
+            q: 'What is 2 + 2?',
+            options: ['3', '4', '5', '2'],
+            answer: 1
+        },
+        {
+            q: 'What is 5 x 3?',
+            options: ['15', '8', '10', '20'],
+            answer: 0
+        },
+        {
+            q: 'What is the square root of 16?',
+            options: ['2', '4', '6', '8'],
+            answer: 1
+        }
+    ],
+    history: [
+        {
+            q: 'Who was the first President of the USA?',
+            options: ['Abraham Lincoln', 'George Washington', 'Thomas Jefferson', 'John Adams'],
+            answer: 1
+        },
+        {
+            q: 'In which year did World War II end?',
+            options: ['1940', '1945', '1950', '1939'],
+            answer: 1
+        },
+        {
+            q: 'The pyramids are located in which country?',
+            options: ['Mexico', 'Greece', 'Egypt', 'India'],
+            answer: 2
+        }
+    ],
+    science: [
+        {
+            q: 'Water freezes at what temperature (C)?',
+            options: ['0', '32', '100', '-10'],
+            answer: 0
+        },
+        {
+            q: 'What planet is known as the Red Planet?',
+            options: ['Mars', 'Venus', 'Jupiter', 'Saturn'],
+            answer: 0
+        },
+        {
+            q: 'Humans breathe which gas?',
+            options: ['Carbon Dioxide', 'Nitrogen', 'Oxygen', 'Hydrogen'],
+            answer: 2
+        }
+    ]
+};
+
+let currentTopic = null;
+let currentQuestionIndex = 0;
+let score = 0;
+let soundOn = true;
+let highScore = parseInt(localStorage.getItem('quizHighScore') || '0');
+
+const startScreen = document.getElementById('start-screen');
+const quizScreen = document.getElementById('quiz-screen');
+const scoreScreen = document.getElementById('score-screen');
+const questionDiv = document.getElementById('question');
+const optionsDiv = document.getElementById('options');
+const nextBtn = document.getElementById('next-btn');
+const finalScoreP = document.getElementById('final-score');
+const highScoreP = document.getElementById('high-score');
+const restartBtn = document.getElementById('restart-btn');
+const soundToggle = document.getElementById('sound-toggle');
+const progressDiv = document.getElementById('progress');
+
+soundToggle.addEventListener('change', () => {
+    soundOn = soundToggle.checked;
+});
+
+function playBeep(correct) {
+    if (!soundOn) return;
+    const duration = 0.2;
+    const frequency = correct ? 440 : 220;
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const oscillator = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+    oscillator.connect(gainNode);
+    gainNode.connect(ctx.destination);
+    oscillator.type = 'sine';
+    oscillator.frequency.value = frequency;
+    oscillator.start();
+    gainNode.gain.setValueAtTime(1, ctx.currentTime);
+    oscillator.stop(ctx.currentTime + duration);
+}
+
+function showQuestion() {
+    const questionObj = questions[currentTopic][currentQuestionIndex];
+    progressDiv.textContent = `Question ${currentQuestionIndex + 1} of ${questions[currentTopic].length}`;
+    questionDiv.textContent = questionObj.q;
+    optionsDiv.innerHTML = '';
+    questionObj.options.forEach((opt, idx) => {
+        const btn = document.createElement('button');
+        btn.textContent = opt;
+        btn.addEventListener('click', () => selectAnswer(idx));
+        optionsDiv.appendChild(btn);
+    });
+    nextBtn.classList.add('hidden');
+}
+
+function selectAnswer(index) {
+    const questionObj = questions[currentTopic][currentQuestionIndex];
+    const buttons = optionsDiv.querySelectorAll('button');
+    buttons.forEach((btn, i) => {
+        btn.disabled = true;
+        if (i === questionObj.answer) {
+            btn.style.backgroundColor = '#8f8';
+        }
+        if (i === index && i !== questionObj.answer) {
+            btn.style.backgroundColor = '#f88';
+        }
+    });
+    if (index === questionObj.answer) {
+        score++;
+        playBeep(true);
+    } else {
+        playBeep(false);
+    }
+    nextBtn.classList.remove('hidden');
+}
+
+function nextQuestion() {
+    currentQuestionIndex++;
+    if (currentQuestionIndex >= questions[currentTopic].length) {
+        showScore();
+    } else {
+        showQuestion();
+    }
+}
+
+function showScore() {
+    quizScreen.classList.add('hidden');
+    scoreScreen.classList.remove('hidden');
+    finalScoreP.textContent = `Your score: ${score} / ${questions[currentTopic].length}`;
+    if (score > highScore) {
+        highScore = score;
+        localStorage.setItem('quizHighScore', highScore);
+    }
+    highScoreP.textContent = `High score: ${highScore}`;
+    highScoreP.classList.remove('hidden');
+}
+
+function restart() {
+    scoreScreen.classList.add('hidden');
+    startScreen.classList.remove('hidden');
+    score = 0;
+    currentQuestionIndex = 0;
+    progressDiv.textContent = '';
+    highScoreP.classList.add('hidden');
+}
+
+function startQuiz(topic) {
+    currentTopic = topic;
+    currentQuestionIndex = 0;
+    score = 0;
+    startScreen.classList.add('hidden');
+    scoreScreen.classList.add('hidden');
+    quizScreen.classList.remove('hidden');
+    highScoreP.classList.add('hidden');
+    progressDiv.textContent = '';
+    showQuestion();
+}
+
+// Event listeners
+
+document.querySelectorAll('.topic-btn').forEach(btn => {
+    btn.addEventListener('click', () => startQuiz(btn.dataset.topic));
+});
+
+nextBtn.addEventListener('click', nextQuestion);
+restartBtn.addEventListener('click', restart);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,45 @@
+body {
+    font-family: Arial, sans-serif;
+    background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    text-align: center;
+    width: 90%;
+    max-width: 500px;
+}
+
+.hidden {
+    display: none;
+}
+
+button {
+    padding: 10px 20px;
+    margin: 10px;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+#high-score {
+    margin-top: 10px;
+    font-size: 18px;
+    color: #333;
+}
+
+.controls {
+    margin-top: 20px;
+}
+
+#progress {
+    margin-bottom: 10px;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add simple `index.html` with topic selection and sound toggle
- style quiz app with `style.css`
- implement quiz logic and audio effects in `script.js`
- show question progress and track high scores

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687940f190c883259412b31f4216564e